### PR TITLE
chore: bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,17 +17,17 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.21.1",
-    "@vitejs/plugin-vue": "^2.1.0",
+    "@vitejs/plugin-vue": "^2.3.2",
     "electron": "18.2.0",
     "electron-builder": "^23.0.3",
     "nano-staged": "^0.8.0",
     "simple-git-hooks": "^2.7.0",
-    "typescript": "^4.6.3",
-    "vite": "^2.9.1",
+    "typescript": "^4.6.4",
+    "vite": "^2.9.8",
     "vite-plugin-electron": "^0.4.3",
-    "vite-plugin-resolve": "^2.0.1",
-    "vue": "^3.2.31",
-    "vue-tsc": "^0.31.1"
+    "vite-plugin-resolve": "^2.0.8",
+    "vue": "^3.2.33",
+    "vue-tsc": "^0.34.11"
   },
   "env": {
     "VITE_DEV_SERVER_HOST": "127.0.0.1",


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?
chore: bump deps
 
@vitejs/plugin-vue    ^2.1.0  →    ^2.3.2     
 typescript            ^4.6.3  →    ^4.6.4     
 vite                  ^2.9.1  →    ^2.9.8     
 vite-plugin-resolve   ^2.0.1  →    ^2.0.8     
 vue                  ^3.2.31  →   ^3.2.33     
 vue-tsc              ^0.31.1  →  ^0.34.11   

#### Issue Number


#### What is the new behavior?



#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions



#### Other information
