### PR TITLE
feat: add CTRL + C exit the application without ask

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -59,7 +59,7 @@ function watchPreload(server) {
   })
 }
 
-// block CTRL + C to exit the application directly without displaying the query in Windows
+// Block the CTRL + C shortcut on a Windows terminal and exit the application without displaying a query
 if (process.platform === 'win32') {
   readline.createInterface({ input: process.stdin, output: process.stdout }).on('SIGINT', process.exit)
 }

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import { createServer, build } from 'vite'
 import electron from 'electron'
+import readline from 'readline'
 
 const query = new URLSearchParams(import.meta.url.split('?')[1])
 const debug = query.has('debug')
@@ -56,6 +57,11 @@ function watchPreload(server) {
       watch: {},
     },
   })
+}
+
+// block CTRL + C to exit the application directly without displaying the query in Windows
+if (process.platform === 'win32') {
+  readline.createInterface({ input: process.stdin, output: process.stdout }).on('SIGINT', process.exit)
 }
 
 // bootstrap


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

You can't close the application directly by typing CTRL + C.

#### What is the new behavior?

Adjust the watch script, block the CTRL + C shortcut on a Windows terminal and exit the application without displaying a query.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
