### PR TITLE
解决引用外部插件时在build时弹出‘*.js is a javascript file..’的问题

### DIFF
--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

The problem '*.js is a javascript file..' pops up at build time when referencing external plugins.

#### Issue Number

Example: \#123

#### What is the new behavior?

Solve the problem that "*.js is a javascript file.." pops up during build when referencing external plugins.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
