### PR TITLE
chore: bump deps

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -17,8 +17,7 @@ process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true'
 let win: BrowserWindow | null = null
 // Here, you can also use other preload
 const preload = join(__dirname, '../preload/index.js')
-// 🚧 Use ['ENV_NAME'] avoid vite:define plugin
-const url = `http://${process.env['VITE_DEV_SERVER_HOST']}:${process.env['VITE_DEV_SERVER_PORT']}`
+const url = `http://${process.env.VITE_DEV_SERVER_HOST}:${process.env.VITE_DEV_SERVER_PORT}`
 
 async function createWindow() {
   win = new BrowserWindow({

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "electron": "^19.0.3",
     "electron-builder": "^23.0.3",
     "typescript": "^4.7.3",
-    "vite": "^2.9.9",
+    "vite": "^3.0.0-beta.5",
     "vite-plugin-electron": "^0.6.1",
     "vite-plugin-resolve": "^2.1.2",
     "vue": "^3.2.36",


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

"vite": "^2.9.9"

`build.lib` mode is now recognized internally by Vite.

```ts
// Bypass build.lib
if (!isBuildLib) {}
```

https://github.com/vitejs/vite/commit/908c9e4cdd2cceb0f01495e38066ffe33c21ddb8#diff-d90a7c21c9fb9222e557704bd906ea5671d5fe384c8fb105459eea8c36fdb4f0R18

#### Issue Number


#### What is the new behavior?

"vite": "^2.9.9" => "vite": "^3.0.0-beta.5",

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Now, 

- [ ] Yes
- [x] No

#### Specific Instructions

#### Other information
