### PR TITLE
fix: temp fix `npm ci` error in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
 
       # - name: Run tests
       #   run: npm run test


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

View in this repo's actions at https://github.com/electron-vite/electron-vite-vue/actions/workflows/release.yml

#### Issue Number

Example: [\#123](https://github.com/electron-vite/electron-vite-vue/issues/173#issuecomment-1171806639)

#### What is the new behavior?

It should fix the dependencies installation error in workflow cuz `npm ci` requires `package-lock.json` or `npm-shrinkwrap.json`, but these files are in `.gitignore` and be deleted in this repo.
So I changed the command to `npm i` (alias to `npm install`) to install dependencies normally.
If you care about some secure reason or something other, you could upload `package-lock.json` back.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] ~~Yes~~
- [x] No

#### Specific Instructions

> Are there any specific instructions or things that should be known prior to review?
No, this PR contains nothing related to this project.

#### Other information
Be happy.