### PR TITLE
Fix dest folder handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build && electron-builder"
+    "build": "vue-tsc --noEmit && vite build && electron-builder",
+    "build:web": "vue-tsc --noEmit && vite build"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
   },
   "references": [
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "exclude": ["dist"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,5 +6,6 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "electron", "package.json"]
+  "include": ["vite.config.ts", "electron", "package.json"],
+  "exclude": ["dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-import { rmSync } from 'fs'
 import { join } from 'path'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,6 @@ import vue from '@vitejs/plugin-vue'
 import electron from 'vite-plugin-electron'
 import pkg from './package.json'
 
-rmSync('dist', { recursive: true, force: true }) // v14.14.0
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -40,5 +38,8 @@ export default defineConfig({
   server: {
     host: pkg.env.VITE_DEV_SERVER_HOST,
     port: pkg.env.VITE_DEV_SERVER_PORT,
+  },
+  build: {
+    emptyOutDir: true,
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`dist` folder is not cleared before `tsc-vue` is run, so the typescript compiler ends up trying to check it and errors during build for production.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
