### PR TITLE
resolve `TypeScript intellisense is disabled on template` & can't use top level `await` expressions.

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
+    "target": "es2017",
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "jsx": "preserve",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "ESNext",
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",


### PR DESCRIPTION
[TypeScript intellisense is disabled on template. To enable, configure `"jsx": "preserve"` in the `"compilerOptions"` property of tsconfig or jsconfig. To disable this prompt instead, configure `"experimentalDisableTemplateSupport": true` in `"vueCompilerOptions"` property.volar]
&
can't use top level `await` expressions.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
