### PR TITLE
feature: 在应用未打包时自动打开 devTools

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,6 +2,8 @@ import { app, BrowserWindow, shell, ipcMain } from 'electron'
 import { release } from 'os'
 import { join } from 'path'
 
+const { isPackaged } = app
+
 // Disable GPU Acceleration for Windows 7
 if (release().startsWith('6.1')) app.disableHardwareAcceleration()
 
@@ -46,12 +48,15 @@ async function createWindow() {
     },
   })
 
-  if (app.isPackaged) {
+  if (isPackaged) {
     win.loadFile(indexHtml)
   } else {
     win.loadURL(url)
     // win.webContents.openDevTools()
   }
+
+  // Open devTool if the app is not packaged
+  !isPackaged && win.webContents.openDevTools()
 
   // Test actively push message to the Electron-Renderer
   win.webContents.on('did-finish-load', () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -52,11 +52,9 @@ async function createWindow() {
     win.loadFile(indexHtml)
   } else {
     win.loadURL(url)
-    // win.webContents.openDevTools()
+    // Open devTool if the app is not packaged
+    win.webContents.openDevTools()
   }
-
-  // Open devTool if the app is not packaged
-  !isPackaged && win.webContents.openDevTools()
 
   // Test actively push message to the Electron-Renderer
   win.webContents.on('did-finish-load', () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,8 +2,6 @@ import { app, BrowserWindow, shell, ipcMain } from 'electron'
 import { release } from 'os'
 import { join } from 'path'
 
-const { isPackaged } = app
-
 // Disable GPU Acceleration for Windows 7
 if (release().startsWith('6.1')) app.disableHardwareAcceleration()
 
@@ -48,7 +46,7 @@ async function createWindow() {
     },
   })
 
-  if (isPackaged) {
+  if (app.isPackaged) {
     win.loadFile(indexHtml)
   } else {
     win.loadURL(url)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

当应用未被打包时，在启动程序时打开 devTools。
原本提供了该功能在 electron 中 17 18 存在异常，但在 electron 19 中已修复
[fix: settings not persisting across devtools loads](https://github.com/electron/electron/pull/33120#issue-1155911166)
[Release Notes for v19.0.0](https://github.com/electron/electron/releases/tag/v19.0.0)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
