### PR TITLE
bump devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^3.0.1",
-    "electron": "^19.0.8",
-    "electron-builder": "^23.1.0",
+    "electron": "^20.0.2",
+    "electron-builder": "^23.3.3",
     "typescript": "^4.7.4",
-    "vite": "^3.0.3",
-    "vite-plugin-electron": "^0.8.1",
+    "vite": "^3.0.5",
+    "vite-plugin-electron": "^0.8.7",
     "vue": "^3.2.37",
-    "vue-tsc": "^0.39.4"
+    "vue-tsc": "^0.40.1"
   },
   "env": {
     "VITE_DEV_SERVER_HOST": "127.0.0.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,6 @@ export default defineConfig({
       // Enables use of Node.js API in the Renderer-process
       renderer: {},
     }),
-    renderBuiltUrl(),
   ],
   server: {
     host: pkg.env.VITE_DEV_SERVER_HOST,
@@ -62,60 +61,4 @@ function withDebug(config: UserConfig): UserConfig {
     })
   }
   return config
-}
-
-// Only worked Vite@3.x #212
-function renderBuiltUrl(): Plugin {
-  // https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L84-L124
-  const KNOWN_ASSET_TYPES = [
-    // images
-    'png',
-    'jpe?g',
-    'jfif',
-    'pjpeg',
-    'pjp',
-    'gif',
-    'svg',
-    'ico',
-    'webp',
-    'avif',
-
-    // media
-    'mp4',
-    'webm',
-    'ogg',
-    'mp3',
-    'wav',
-    'flac',
-    'aac',
-
-    // fonts
-    'woff2?',
-    'eot',
-    'ttf',
-    'otf',
-
-    // other
-    'webmanifest',
-    'pdf',
-    'txt'
-  ]
-
-  return {
-    name: 'render-built-url',
-    config(config) {
-      config.experimental = {
-        renderBuiltUrl(filename, type) {
-          if (
-            KNOWN_ASSET_TYPES.includes(path.extname(filename).slice(1)) &&
-            type.hostType === 'js'
-          ) {
-            // Avoid Vite relative-path assets handling
-            // https://github.com/vitejs/vite/blob/89dd31cfe228caee358f4032b31fdf943599c842/packages/vite/src/node/build.ts#L838-L875
-            return { runtime: JSON.stringify(filename) }
-          }
-        },
-      }
-    },
-  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
- bump devDependencies
 electron              ^19.0.8  →  ^20.0.2     
 electron-builder      ^23.1.0  →  ^23.3.3     
 vite                   ^3.0.3  →   ^3.0.5     
 vite-plugin-electron   ^0.8.1  →   ^0.8.7     
 vue-tsc               ^0.39.4  →  ^0.40.1  

- remove `renderBuiltUrl` plugin, it integrated in [vite-plugin-electron](https://github.com/electron-vite/vite-plugin-electron/commit/1cc4f40e5815cc38519eb3718752096a639de3c3)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
