### PR TITLE
fix: incorrect problemMatcher patterns

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,8 @@
         },
         "background": {
           "activeOnStart": true,
-          "endsPattern": "^.*[startup] Electron App.*$",
+          "beginsPattern": "^.*VITE v.*  ready in \\d* ms.*$",
+          "endsPattern": "^.*\\[startup\\] Electron App.*$"
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`tasks.json`
```diff
// fix incorrect problemMatcher endsPattern
-  "endsPattern": "^.*[startup] Electron App.*$",
+  "endsPattern": "^.*\\[startup\\] Electron App.*$"

// and add beginsPattern
+ "beginsPattern": "^.*VITE v.*  ready in \\d* ms.*$",
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
