### PR TITLE
fix: type reference in electron/electron-env.d.ts

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="vite-electron-plugin/electron-env" />
+/// <reference types="vite-plugin-electron/electron-env" />
 
 declare namespace NodeJS {
   interface ProcessEnv {


### PR DESCRIPTION
Resolve TS error "Cannot find type definition file for 'vite-electron/electron-env'"

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
