### PR TITLE
Exclude node_modules from build asar

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -11,7 +11,8 @@
   },
   "files": [
     "dist",
-    "dist-electron"
+    "dist-electron",
+    "!node_modules"
   ],
   "mac": {
     "target": [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Excluding the folder "node_modules" from reaching the build asar file because its not needed there and its only increasing the build size.

Size of the build will decrease to at least 50%.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
